### PR TITLE
Integrate basic Sanity CMS client

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,33 @@ npm start
 ```
 
 The project was initialized manually and uses `react-scripts` for development and build tasks.
+
+## Sanity CMS Integration
+
+The project now includes a basic setup for fetching content from
+[Sanity.io](https://www.sanity.io). The `@sanity/client` dependency is listed in
+`package.json` and the `src/sanityClient.js` file configures the connection.
+
+To use your own Sanity project:
+
+1. Create a `.env` file at the project root and define the following variables:
+
+   ```bash
+   REACT_APP_SANITY_PROJECT_ID=yourProjectId
+   REACT_APP_SANITY_DATASET=production
+   ```
+
+2. Install dependencies (requires internet access):
+
+   ```bash
+   npm install
+   ```
+
+3. Start the development server:
+
+   ```bash
+   npm start
+   ```
+
+The `Posts` component demonstrates how to query posts from Sanity and display
+their titles in the app.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-scripts": "5.0.1"
+    "react-scripts": "5.0.1",
+    "@sanity/client": "^5.18.1"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/App.js
+++ b/src/App.js
@@ -1,9 +1,11 @@
 import React from 'react';
+import Posts from './Posts';
 
 function App() {
   return (
     <div className="App">
       <h1>Welcome to Luminex React App</h1>
+      <Posts />
     </div>
   );
 }

--- a/src/Posts.js
+++ b/src/Posts.js
@@ -1,0 +1,25 @@
+import React, { useEffect, useState } from 'react';
+import client from './sanityClient';
+
+// Simple component that fetches and displays posts from Sanity.
+export default function Posts() {
+  const [posts, setPosts] = useState([]);
+
+  useEffect(() => {
+    client
+      .fetch('*[_type == "post"]{_id, title}')
+      .then(setPosts)
+      .catch((err) => console.error('Sanity fetch error:', err));
+  }, []);
+
+  return (
+    <div>
+      <h2>Posts from Sanity</h2>
+      <ul>
+        {posts.map((post) => (
+          <li key={post._id}>{post.title}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/sanityClient.js
+++ b/src/sanityClient.js
@@ -1,0 +1,11 @@
+import sanityClient from '@sanity/client';
+
+// Configuration for Sanity client. Replace the placeholders with your project
+// specific settings. These values can also be provided via environment
+// variables in a .env file.
+export default sanityClient({
+  projectId: process.env.REACT_APP_SANITY_PROJECT_ID || '<your-project-id>',
+  dataset: process.env.REACT_APP_SANITY_DATASET || 'production',
+  useCdn: true,
+  apiVersion: '2023-06-01',
+});


### PR DESCRIPTION
## Summary
- configure Sanity client and simple Posts component
- display Sanity posts in `App`
- document how to configure Sanity and install dependencies
- add `@sanity/client` to package.json

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `CI=true npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887b0b189fc8329b946598b0a70ae1b