### PR TITLE
Improve mobile gallery layout

### DIFF
--- a/src/Gallery.css
+++ b/src/Gallery.css
@@ -6,7 +6,11 @@
   margin-top: 20px;
 }
 
-.gallery img {
+.gallery-item {
+  text-align: center;
+}
+
+.gallery-item img {
   width: 100%;
   max-width: 150px;
   height: auto;
@@ -14,8 +18,19 @@
   border-radius: 4px;
 }
 
+@media (max-width: 600px) {
+  .gallery {
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .gallery-item img {
+    max-width: 100%;
+  }
+}
+
 @media (min-width: 600px) {
-  .gallery img {
+  .gallery-item img {
     width: 150px;
     height: 100px;
   }

--- a/src/Gallery.js
+++ b/src/Gallery.js
@@ -13,7 +13,10 @@ export default function Gallery() {
   return (
     <div id="gallery" className="gallery">
       {images.map((src, index) => (
-        <img key={index} src={src} alt={`Gallery pic ${index + 1}`} />
+        <div className="gallery-item" key={index}>
+          <h3>Foto {index + 1}</h3>
+          <img src={src} alt={`Gallery pic ${index + 1}`} />
+        </div>
       ))}
     </div>
   );


### PR DESCRIPTION
## Summary
- make gallery images single-column on mobile
- add simple heading for each photo

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6887cedac4348329a943f9db232ab059