### PR TITLE
Improve mobile contact form

### DIFF
--- a/src/Contact.css
+++ b/src/Contact.css
@@ -17,11 +17,25 @@
   text-align: left;
 }
 
+.form-group label {
+  margin-bottom: 5px;
+}
+
 .form-group input,
 .form-group textarea {
+  width: 100%;
+  box-sizing: border-box;
   padding: 8px;
   border: 1px solid #ccc;
   border-radius: 4px;
+}
+
+@media (max-width: 600px) {
+  .form-group input,
+  .form-group textarea {
+    padding: 12px;
+    font-size: 1.1rem;
+  }
 }
 
 button[type="submit"] {

--- a/src/Contact.js
+++ b/src/Contact.js
@@ -7,22 +7,16 @@ export default function Contact() {
       <h2>Kontakt</h2>
       <form action="mailto:Daniel.rusnok@gmail.com" method="post" encType="text/plain">
         <div className="form-group">
-          <label>
-            Jméno:
-            <input type="text" name="name" required />
-          </label>
+          <label htmlFor="name">Jméno:</label>
+          <input type="text" id="name" name="name" required />
         </div>
         <div className="form-group">
-          <label>
-            Email:
-            <input type="email" name="email" required />
-          </label>
+          <label htmlFor="email">Email:</label>
+          <input type="email" id="email" name="email" required />
         </div>
         <div className="form-group">
-          <label>
-            Zpráva:
-            <textarea name="message" required />
-          </label>
+          <label htmlFor="message">Zpráva:</label>
+          <textarea id="message" name="message" required />
         </div>
         <button type="submit">Odeslat</button>
       </form>


### PR DESCRIPTION
## Summary
- better align contact form labels and fields
- make input boxes expand to full width and larger on mobile

## Testing
- `npm test --silent -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6887d45332fc83299b170d98c13c9249