### PR TITLE
Enable gallery flip and fullscreen interaction

### DIFF
--- a/src/Gallery.css
+++ b/src/Gallery.css
@@ -6,8 +6,44 @@
   margin-top: 20px;
 }
 
+
 .gallery-item {
   text-align: center;
+  perspective: 1000px;
+  position: relative;
+}
+
+.gallery-item.full {
+  flex-basis: 100%;
+}
+
+.flip-card {
+  position: relative;
+  transition: transform 0.6s;
+  transform-style: preserve-3d;
+}
+
+.flip-card.flipped {
+  transform: rotateY(180deg);
+}
+
+.flip-card .front,
+.flip-card .back {
+  backface-visibility: hidden;
+}
+
+.flip-card .back {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #fff;
+  border-radius: 4px;
+  transform: rotateY(180deg);
 }
 
 .gallery-item img {
@@ -16,6 +52,10 @@
   height: auto;
   object-fit: cover;
   border-radius: 4px;
+}
+
+.gallery-item.full img {
+  max-width: none;
 }
 
 @media (max-width: 600px) {

--- a/src/Gallery.js
+++ b/src/Gallery.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import './Gallery.css';
 
 // Simple component that renders a gallery of images.
@@ -10,14 +10,46 @@ export default function Gallery() {
     'https://picsum.photos/id/1035/300/200'
   ];
 
+  const [states, setStates] = useState(
+    images.map(() => ({ flipped: false, full: false }))
+  );
+
+  const handleClick = (index, e) => {
+    if (e.detail === 2) {
+      setStates(prev =>
+        prev.map((s, i) =>
+          i === index ? { ...s, full: !s.full } : s
+        )
+      );
+    } else {
+      setStates(prev =>
+        prev.map((s, i) =>
+          i === index ? { ...s, flipped: !s.flipped } : s
+        )
+      );
+    }
+  };
+
   return (
     <div id="gallery" className="gallery">
-      {images.map((src, index) => (
-        <div className="gallery-item" key={index}>
-          <h3>Foto {index + 1}</h3>
-          <img src={src} alt={`Gallery pic ${index + 1}`} />
-        </div>
-      ))}
+      {images.map((src, index) => {
+        const { flipped, full } = states[index];
+        return (
+          <div
+            className={`gallery-item ${full ? 'full' : ''}`}
+            key={index}
+            onClick={e => handleClick(index, e)}
+          >
+            <h3>Foto {index + 1}</h3>
+            <div className={`flip-card ${flipped ? 'flipped' : ''}`}>
+              <img className="front" src={src} alt={`Gallery pic ${index + 1}`} />
+              <div className="back">
+                <p>Popis obrázku {index + 1}</p>
+              </div>
+            </div>
+          </div>
+        );
+      })}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add interactive click handlers to Gallery component
- animate image flip to show description
- allow double-click to open image at full width

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6887d72819c48329b1b6660ec495d6df