### PR TITLE
Improve mobile layout and redesign colors

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,3 +1,16 @@
 .App {
   text-align: center;
 }
+
+.mobile-title {
+  display: none;
+  font-size: 1.5rem;
+  margin: 10px 0;
+  color: #2196f3;
+}
+
+@media (max-width: 600px) {
+  .mobile-title {
+    display: block;
+  }
+}

--- a/src/App.js
+++ b/src/App.js
@@ -8,6 +8,7 @@ function App() {
   return (
     <div className="App">
       <Navbar />
+      <h1 className="mobile-title">Daniel Rusnok Portfolio</h1>
       <Gallery />
       <Contact />
       <Footer />

--- a/src/Contact.css
+++ b/src/Contact.css
@@ -2,8 +2,9 @@
   margin: 40px auto;
   max-width: 500px;
   padding: 20px;
-  border: 1px solid #ccc;
+  border: 1px solid #2196f3;
   border-radius: 4px;
+  background-color: #e3f2fd;
 }
 
 .contact h2 {
@@ -26,7 +27,7 @@
   width: 100%;
   box-sizing: border-box;
   padding: 8px;
-  border: 1px solid #ccc;
+  border: 1px solid #2196f3;
   border-radius: 4px;
 }
 
@@ -41,7 +42,7 @@
 button[type="submit"] {
   padding: 10px 15px;
   border: none;
-  background-color: #333;
+  background-color: #2196f3;
   color: #fff;
   cursor: pointer;
   border-radius: 4px;

--- a/src/Footer.css
+++ b/src/Footer.css
@@ -1,6 +1,6 @@
 .footer {
   text-align: center;
   padding: 20px;
-  background-color: #f0f0f0;
+  background-color: #e3f2fd;
   margin-top: 40px;
 }

--- a/src/Gallery.css
+++ b/src/Gallery.css
@@ -41,7 +41,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  background: #fff;
+  background: #e3f2fd;
   border-radius: 4px;
   transform: rotateY(180deg);
 }

--- a/src/Navbar.css
+++ b/src/Navbar.css
@@ -3,7 +3,8 @@
   align-items: center;
   justify-content: space-between;
   padding: 10px 20px;
-  background-color: #f8f8f8;
+  background-color: #2196f3;
+  color: #fff;
 }
 
 .navbar-menu {
@@ -50,13 +51,17 @@
 .burger .line {
   width: 25px;
   height: 3px;
-  background-color: #333;
+  background-color: #fff;
   margin: 4px 0;
 }
 
 @media (max-width: 600px) {
   .burger {
     display: flex;
+  }
+
+  .navbar-center {
+    display: none;
   }
 
   .navbar-menu {

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,5 @@
 body {
   margin: 0;
   font-family: sans-serif;
+  background-color: #fafafa;
 }


### PR DESCRIPTION
## Summary
- move portfolio heading outside Navbar and show it only on mobile
- hide heading inside nav on small screens
- switch color palette to blue/white for navbar, contact form, gallery and footer
- set light page background

## Testing
- `npm test --silent -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6888496749b08329854fd4982f1fb9b0