### PR TITLE
Fix module import path for build

### DIFF
--- a/src/Gallery.js
+++ b/src/Gallery.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import './Gallery.css';
-import ModalCarousel from './ModalCarousel';
+import ModalCarousel from './ModalCarousel.js';
 
 // Simple component that renders a gallery of images.
 export default function Gallery() {


### PR DESCRIPTION
## Summary
- add `.js` extension to `ModalCarousel` import so React Scripts resolves module in ESM mode

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68885f38d8908329a0d96671df071698