### PR TITLE
Fix mobile burger menu height and sticky navbar

### DIFF
--- a/src/Navbar.css
+++ b/src/Navbar.css
@@ -5,6 +5,12 @@
   padding: 10px 20px;
   background-color: #9c27b0;
   color: #fff;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  z-index: 1000;
+  box-sizing: border-box;
 }
 
 .navbar-menu {
@@ -78,7 +84,7 @@
     flex-direction: column;
     width: 100%;
     margin-top: 10px;
-    min-height: calc(100vh - 60px);
+    height: auto;
   }
 
   .navbar-menu.open {

--- a/src/index.css
+++ b/src/index.css
@@ -4,6 +4,7 @@ body {
   margin: 0;
   font-family: sans-serif;
   background-color: #fafafa;
+  padding-top: 60px;
 }
 
 h1 {


### PR DESCRIPTION
## Summary
- keep `navbar` fixed to top of the viewport
- make burger menu height adapt to its content
- offset page body to account for fixed navbar

## Testing
- `npm test -- --watchAll=false` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_688869ff8a888329910d2fe1a42afd21