### PR TITLE
Center mobile contact heading

### DIFF
--- a/src/Contact.css
+++ b/src/Contact.css
@@ -9,6 +9,7 @@
 
 .contact h2 {
   margin-bottom: 20px;
+  text-align: center;
 }
 
 .form-group {


### PR DESCRIPTION
## Summary
- center the Kontakt section heading so it's centered on mobile

## Testing
- `CI=true npm test --silent` *(fails: No tests found)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68886a149858832984a9f5915642ed8c