### PR TITLE
Enable swipe carousel and viewport modal

### DIFF
--- a/src/ModalCarousel.css
+++ b/src/ModalCarousel.css
@@ -16,7 +16,8 @@
   background: #fff;
   padding: 20px;
   max-width: 90%;
-  max-height: 90%;
+  max-height: 100vh;
+  overflow-y: auto;
   text-align: center;
 }
 

--- a/src/ModalCarousel.js
+++ b/src/ModalCarousel.js
@@ -1,8 +1,9 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import './ModalCarousel.css';
 
 export default function ModalCarousel({ images, startIndex, onClose }) {
   const [current, setCurrent] = useState(startIndex);
+  const startXRef = useRef(0);
 
   const next = () => setCurrent((c) => (c + 1) % images.length);
   const prev = () => setCurrent((c) => (c - 1 + images.length) % images.length);
@@ -17,11 +18,32 @@ export default function ModalCarousel({ images, startIndex, onClose }) {
     return () => document.removeEventListener('keydown', handleKey);
   }, [onClose]);
 
+  const handleTouchStart = (e) => {
+    startXRef.current = e.touches[0].clientX;
+  };
+
+  const handleTouchEnd = (e) => {
+    const endX = e.changedTouches[0].clientX;
+    const diff = startXRef.current - endX;
+    if (diff > 50) {
+      next();
+    } else if (diff < -50) {
+      prev();
+    }
+  };
+
   return (
     <div className="modal-overlay" onClick={onClose}>
-      <div className="modal" onClick={(e) => e.stopPropagation()}>
+      <div
+        className="modal"
+        onClick={(e) => e.stopPropagation()}
+      >
         <button className="close" onClick={onClose} aria-label="close">&times;</button>
-        <div className="carousel">
+        <div
+          className="carousel"
+          onTouchStart={handleTouchStart}
+          onTouchEnd={handleTouchEnd}
+        >
           <button className="nav prev" onClick={prev} aria-label="previous">&lt;</button>
           <img src={images[current]} alt={`Gallery pic ${current + 1}`} />
           <button className="nav next" onClick={next} aria-label="next">&gt;</button>


### PR DESCRIPTION
## Summary
- allow swiping left/right on the modal carousel
- keep modal within the viewport

## Testing
- `npm test -- --watchAll=false --passWithNoTests`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68886a75cc8c8329b42191e7509cf732