### PR TITLE
Fix image flip on double click

### DIFF
--- a/src/Gallery.js
+++ b/src/Gallery.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import './Gallery.css';
 import ModalCarousel from './ModalCarousel.js';
 
@@ -16,15 +16,34 @@ export default function Gallery() {
   );
   const [modalIndex, setModalIndex] = useState(0);
   const [modalOpen, setModalOpen] = useState(false);
+  const flipTimeouts = useRef(images.map(() => null));
+
+  useEffect(() => {
+    return () => {
+      flipTimeouts.current.forEach((t) => t && clearTimeout(t));
+    };
+  }, []);
+
+  const FLIP_DELAY = 250;
 
   const handleClick = (index, e) => {
     if (e.detail === 2) {
+      if (flipTimeouts.current[index]) {
+        clearTimeout(flipTimeouts.current[index]);
+        flipTimeouts.current[index] = null;
+      }
       setModalIndex(index);
       setModalOpen(true);
     } else {
-      setFlippedStates((prev) =>
-        prev.map((f, i) => (i === index ? !f : f))
-      );
+      if (flipTimeouts.current[index]) {
+        clearTimeout(flipTimeouts.current[index]);
+      }
+      flipTimeouts.current[index] = setTimeout(() => {
+        setFlippedStates((prev) =>
+          prev.map((f, i) => (i === index ? !f : f))
+        );
+        flipTimeouts.current[index] = null;
+      }, FLIP_DELAY);
     }
   };
 


### PR DESCRIPTION
## Summary
- prevent card flip on double-click
- add delay before flipping so modal open cancels flip

## Testing
- `npm test -- --watchAll=false --passWithNoTests`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68886aec532483299925a3641c4fd940