### PR TITLE
Add tag intersection filtering

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import Gallery from './components/Gallery/Gallery';
 import Navbar from './components/Navbar/Navbar';
 import Footer from './components/Footer/Footer';
@@ -7,13 +7,15 @@ import Contact from './components/Contact';
 import Filter from './components/Filter/Filter';
 
 function App() {
+  const [selectedTags, setSelectedTags] = useState<string[]>([]);
+
   return (
     <>
       <GlobalStyle />
       <Layout>
         <Navbar />
-        <Filter />
-        <Gallery />
+        <Filter selectedTags={selectedTags} onChange={setSelectedTags} />
+        <Gallery selectedTags={selectedTags} />
         <Contact />
         <Footer />
       </Layout>

--- a/src/components/Filter/Filter.tsx
+++ b/src/components/Filter/Filter.tsx
@@ -2,7 +2,12 @@ import React, { useEffect, useState } from 'react';
 import { sanityClient } from '../../sanityClient';
 import { FilterWrapper, CheckboxLabel } from './styled';
 
-export default function Filter() {
+interface FilterProps {
+  selectedTags: string[];
+  onChange: (tags: string[]) => void;
+}
+
+export default function Filter({ selectedTags, onChange }: FilterProps) {
   const [tags, setTags] = useState<string[]>([]);
 
   useEffect(() => {
@@ -23,11 +28,25 @@ export default function Filter() {
     fetchTags();
   }, []);
 
+  const handleCheckboxChange = (tag: string) => {
+    if (selectedTags.includes(tag)) {
+      onChange(selectedTags.filter((t) => t !== tag));
+    } else {
+      onChange([...selectedTags, tag]);
+    }
+  };
+
   return (
     <FilterWrapper>
       {tags.map((tag) => (
         <CheckboxLabel key={tag}>
-          <input type="checkbox" id={tag} name={tag} />
+          <input
+            type="checkbox"
+            id={tag}
+            name={tag}
+            checked={selectedTags.includes(tag)}
+            onChange={() => handleCheckboxChange(tag)}
+          />
           <span>#{tag}</span>
         </CheckboxLabel>
       ))}

--- a/src/components/Gallery/Gallery.tsx
+++ b/src/components/Gallery/Gallery.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import { GalleryWrapper, GalleryItem, TagsWrapper } from './styled';
 import ImageSkeleton from './ImageSkeleton';
 import ModalCarousel from '../ModalCarousel/ModalCarousel'; // ModalCarousel nyní očekává images: {url, description}[]
@@ -7,11 +7,15 @@ import GalleryTag from '../GalleryTag/GalleryTag';
 import { sanityClient } from '../../sanityClient';
 
 // Simple component that renders a gallery of images.
-export default function Gallery() {
+interface GalleryProps {
+  selectedTags: string[];
+}
+
+export default function Gallery({ selectedTags }: GalleryProps) {
   const [images, setImages] = useState<any[]>([]);
   const [modalIndex, setModalIndex] = useState(0);
   const [modalOpen, setModalOpen] = useState(false);
-  const [loaded, setLoaded] = useState<boolean[]>([]);
+  const [loaded, setLoaded] = useState<Record<string, boolean>>({});
 
   useEffect(() => {
     async function fetchImages() {
@@ -25,10 +29,11 @@ export default function Gallery() {
       const data = await (sanityClient as any).fetch(query);
       setImages(data);
       setLoaded((prev) => {
-        // Pokud už máme loaded pro stejný počet obrázků, zachováme je
-        if (prev.length === data.length) return prev;
-        // Jinak nastavíme vše na false (např. při změně počtu obrázků)
-        return data.map(() => false);
+        const map: Record<string, boolean> = {};
+        data.forEach((img: any) => {
+          map[img._id] = prev[img._id] || false;
+        });
+        return map;
       });
     }
     fetchImages();
@@ -39,39 +44,44 @@ export default function Gallery() {
     setModalOpen(true);
   };
 
-  const handleImgLoad = (idx: number) => {
-    setLoaded((prev) => prev.map((v, i) => (i === idx ? true : v)));
+  const handleImgLoad = (id: string) => {
+    setLoaded((prev) => ({ ...prev, [id]: true }));
   };
+
+  const filteredImages = useMemo(() => {
+    if (!selectedTags.length) return images;
+    return images.filter(
+      (img) => Array.isArray(img.tags) && selectedTags.every((tag) => img.tags.includes(tag))
+    );
+  }, [images, selectedTags]);
 
   return (
     <>
       <GalleryWrapper id="gallery">
-        {images.map((img, index) => (
+        {filteredImages.map((img, index) => (
           <GalleryItem key={img._id}>
             <h2>{img.title || `Foto ${index + 1}`}</h2>
-            {!loaded[index] && <ImageSkeleton />}
+            {!loaded[img._id] && <ImageSkeleton />}
             <div onClick={() => handleClick(index)} style={{ cursor: 'pointer' }}>
               <GalleryImage
                 src={img.url}
                 alt={img.description || `Gallery pic ${index + 1}`}
-                loaded={loaded[index]}
-                onLoad={() => handleImgLoad(index)}
+                loaded={!!loaded[img._id]}
+                onLoad={() => handleImgLoad(img._id)}
               />
             </div>
             <TagsWrapper>
               {Array.isArray(img.tags) &&
                 img.tags
                   .filter((tag: string) => tag && tag.trim() !== '')
-                  .map((tag: string) => (
-                    <GalleryTag key={tag} tag={tag} />
-                  ))}
+                  .map((tag: string) => <GalleryTag key={tag} tag={tag} />)}
             </TagsWrapper>
           </GalleryItem>
         ))}
       </GalleryWrapper>
-      {modalOpen && images[modalIndex] && (
+      {modalOpen && filteredImages[modalIndex] && (
         <ModalCarousel
-          images={images.map((img) => ({ url: img.url, description: img.description }))}
+          images={filteredImages.map((img) => ({ url: img.url, description: img.description }))}
           startIndex={modalIndex}
           onClose={() => setModalOpen(false)}
         />


### PR DESCRIPTION
## Summary
- enable filter component to manage selected tags
- pass selected tags through `App` to `Gallery`
- update gallery to apply tag intersection filtering and show modal for filtered list

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6889db4a8f18832980e3fec3d233a9be