### PR TITLE
Make filter collapsible

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,7 @@ import Navbar from './components/Navbar/Navbar';
 import Footer from './components/Footer/Footer';
 import { Layout, GlobalStyle } from './styled';
 import Contact from './components/Contact';
-import Filter from './components/Filter/Filter';
+import FilterDropdown from './components/Filter/Dropdown';
 
 function App() {
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
@@ -14,7 +14,7 @@ function App() {
       <GlobalStyle />
       <Layout>
         <Navbar />
-        <Filter selectedTags={selectedTags} onChange={setSelectedTags} />
+        <FilterDropdown selectedTags={selectedTags} onChange={setSelectedTags} />
         <Gallery selectedTags={selectedTags} />
         <Contact />
         <Footer />

--- a/src/components/Filter/Dropdown.tsx
+++ b/src/components/Filter/Dropdown.tsx
@@ -1,0 +1,21 @@
+import React, { useState } from 'react';
+import Filter from './Filter';
+import { DropdownWrapper, ToggleButton } from './styled';
+
+interface DropdownProps {
+  selectedTags: string[];
+  onChange: (tags: string[]) => void;
+}
+
+export default function Dropdown({ selectedTags, onChange }: DropdownProps) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <DropdownWrapper>
+      <ToggleButton onClick={() => setOpen((o) => !o)}>
+        {open ? 'Hide Filters' : 'Show Filters'}
+      </ToggleButton>
+      {open && <Filter selectedTags={selectedTags} onChange={onChange} />}
+    </DropdownWrapper>
+  );
+}

--- a/src/components/Filter/styled.ts
+++ b/src/components/Filter/styled.ts
@@ -15,3 +15,18 @@ export const CheckboxLabel = styled.label`
   font-weight: 600;
   font-size: 18px;
 `;
+
+export const DropdownWrapper = styled.div`
+  text-align: center;
+  margin: 20px auto;
+`;
+
+export const ToggleButton = styled.button`
+  padding: 10px 15px;
+  border: none;
+  background-color: #9c27b0;
+  color: #fff;
+  cursor: pointer;
+  border-radius: 4px;
+  font-weight: bold;
+`;


### PR DESCRIPTION
## Summary
- add dropdown wrapper for Filter component
- hide Filter by default and show on toggle
- display the dropdown in App

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6889e57fd1408329af4b9d6fe2d7d688