### PR TITLE
Make filter collapsible

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,8 @@ import Navbar from './components/Navbar/Navbar';
 import Footer from './components/Footer/Footer';
 import { Layout, GlobalStyle } from './styled';
 import Contact from './components/Contact';
-import Filter from './components/Filter/Filter';
+import FilterDropdown from './components/Filter/Dropdown';
+import ScrollToTopButton from './components/ScrollToTopButton';
 
 function App() {
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
@@ -14,11 +15,12 @@ function App() {
       <GlobalStyle />
       <Layout>
         <Navbar />
-        <Filter selectedTags={selectedTags} onChange={setSelectedTags} />
+        <FilterDropdown selectedTags={selectedTags} onChange={setSelectedTags} />
         <Gallery selectedTags={selectedTags} />
         <Contact />
         <Footer />
       </Layout>
+      <ScrollToTopButton />
     </>
   );
 }

--- a/src/components/ArrowUpIcon/index.tsx
+++ b/src/components/ArrowUpIcon/index.tsx
@@ -1,0 +1,11 @@
+import * as React from 'react';
+
+export type ArrowUpIconProps = {
+  color?: string;
+};
+
+export const ArrowUpIcon: React.FC<ArrowUpIconProps> = ({ color = 'currentColor' }) => (
+  <svg width="48" height="48" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+    <path d="M12 4l-8 8h5v8h6v-8h5l-8-8z" fill={color} />
+  </svg>
+);

--- a/src/components/Filter/Dropdown.tsx
+++ b/src/components/Filter/Dropdown.tsx
@@ -1,0 +1,21 @@
+import React, { useState } from 'react';
+import Filter from './Filter';
+import { DropdownWrapper, ToggleButton } from './styled';
+
+interface DropdownProps {
+  selectedTags: string[];
+  onChange: (tags: string[]) => void;
+}
+
+export default function Dropdown({ selectedTags, onChange }: DropdownProps) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <DropdownWrapper>
+      <ToggleButton onClick={() => setOpen((o) => !o)}>
+        {open ? 'Hide Filters' : 'Show Filters'}
+      </ToggleButton>
+      {open && <Filter selectedTags={selectedTags} onChange={onChange} />}
+    </DropdownWrapper>
+  );
+}

--- a/src/components/Filter/styled.ts
+++ b/src/components/Filter/styled.ts
@@ -15,3 +15,18 @@ export const CheckboxLabel = styled.label`
   font-weight: 600;
   font-size: 18px;
 `;
+
+export const DropdownWrapper = styled.div`
+  text-align: center;
+  margin: 20px auto;
+`;
+
+export const ToggleButton = styled.button`
+  padding: 10px 15px;
+  border: none;
+  background-color: #9c27b0;
+  color: #fff;
+  cursor: pointer;
+  border-radius: 4px;
+  font-weight: bold;
+`;

--- a/src/components/ScrollToTopButton/index.tsx
+++ b/src/components/ScrollToTopButton/index.tsx
@@ -1,0 +1,25 @@
+import React, { useEffect, useState } from 'react';
+import { Button } from './styled';
+import { ArrowUpIcon } from '../ArrowUpIcon';
+
+export default function ScrollToTopButton() {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      setVisible(window.scrollY > 100);
+    };
+    window.addEventListener('scroll', handleScroll);
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, []);
+
+  const scrollToTop = () => {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  };
+
+  return (
+    <Button onClick={scrollToTop} $visible={visible} aria-label="scroll to top">
+      <ArrowUpIcon color="white" />
+    </Button>
+  );
+}

--- a/src/components/ScrollToTopButton/styled.ts
+++ b/src/components/ScrollToTopButton/styled.ts
@@ -1,0 +1,18 @@
+import styled from 'styled-components';
+
+export const Button = styled.button<{ $visible: boolean }>`
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  border: none;
+  background-color: #9c27b0;
+  color: white;
+  cursor: pointer;
+  display: ${({ $visible }) => ($visible ? 'flex' : 'none')};
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+`;


### PR DESCRIPTION
## Summary
- merge main branch and add new scroll-to-top button components
- create FilterDropdown component to hide filters by default
- use FilterDropdown in App alongside the new scroll button

## Testing
- `npm test --silent` *(failed: no output)*

------
https://chatgpt.com/codex/tasks/task_e_6889e57fd1408329af4b9d6fe2d7d688