### PR TITLE
Add exhibitions section

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { ThemeProvider } from 'styled-components';
 import Contact from './components/Contact';
 import ScrollToTopButton from './components/ScrollToTopButton';
 import { Portfolio } from './components/Portfolio';
+import Exhibitions from './components/Exhibitions';
 import { luminexTheme } from './theme';
 
 function App() {
@@ -16,6 +17,7 @@ function App() {
       <Layout>
         <Navbar />
         <HeroSection />
+        <Exhibitions />
         <Portfolio />
         <Contact />
         <Footer />

--- a/src/components/Exhibitions/index.tsx
+++ b/src/components/Exhibitions/index.tsx
@@ -1,0 +1,66 @@
+import React, { useEffect, useState } from 'react';
+import {
+  ExhibitionsSection,
+  ExhibitionsTitle,
+  ExhibitionsGrid,
+  ExhibitionCard,
+  ExhibitionImage,
+  ExhibitionDate,
+  ExhibitionDescription,
+  ExhibitionAddress,
+} from './styled';
+import { sanityClient } from '../../sanityClient';
+
+interface Exhibition {
+  _id: string;
+  name: string;
+  description?: string;
+  address?: string;
+  dateOfExhibition?: string;
+  photoUrl?: string;
+}
+
+export default function Exhibitions() {
+  const [exhibitions, setExhibitions] = useState<Exhibition[]>([]);
+
+  useEffect(() => {
+    async function fetchExhibitions() {
+      const query = `*[_type == "exhibition"]|order(dateOfExhibition desc){
+        _id,
+        name,
+        description,
+        address,
+        dateOfExhibition,
+        "photoUrl": photo.asset->url
+      }`;
+      const data = await (sanityClient as any).fetch(query);
+      setExhibitions(data);
+    }
+    fetchExhibitions();
+  }, []);
+
+  return (
+    <ExhibitionsSection id="exhibitions">
+      <ExhibitionsTitle>VÝSTAVY</ExhibitionsTitle>
+      <ExhibitionsGrid>
+        {exhibitions.map((ex) => (
+          <ExhibitionCard key={ex._id}>
+            <h3>{ex.name}</h3>
+            {ex.dateOfExhibition && (
+              <ExhibitionDate>
+                {new Date(ex.dateOfExhibition).toLocaleDateString('cs-CZ')}
+              </ExhibitionDate>
+            )}
+            {ex.photoUrl && (
+              <ExhibitionImage src={ex.photoUrl} alt={ex.name} loading="lazy" />
+            )}
+            {ex.description && (
+              <ExhibitionDescription>{ex.description}</ExhibitionDescription>
+            )}
+            {ex.address && <ExhibitionAddress>{ex.address}</ExhibitionAddress>}
+          </ExhibitionCard>
+        ))}
+      </ExhibitionsGrid>
+    </ExhibitionsSection>
+  );
+}

--- a/src/components/Exhibitions/styled.ts
+++ b/src/components/Exhibitions/styled.ts
@@ -1,0 +1,55 @@
+import styled from 'styled-components';
+import { luminexTheme } from '../../theme';
+
+export const ExhibitionsSection = styled.section`
+  width: 100%;
+  max-width: ${luminexTheme.breakpoints.desktop};
+  margin: 40px auto 0 auto;
+  padding: 0 24px;
+  box-sizing: border-box;
+`;
+
+export const ExhibitionsTitle = styled.h2`
+  padding-left: 24px;
+  @media (max-width: ${luminexTheme.breakpoints.tablet}) {
+    text-align: center;
+    padding-left: 0;
+  }
+`;
+
+export const ExhibitionsGrid = styled.div`
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 32px;
+  margin-top: 24px;
+
+  @media (min-width: ${luminexTheme.breakpoints.tablet}) {
+    grid-template-columns: 1fr 1fr;
+  }
+`;
+
+export const ExhibitionCard = styled.div`
+  text-align: center;
+`;
+
+export const ExhibitionImage = styled.img`
+  width: 100%;
+  height: auto;
+  margin-top: 8px;
+`;
+
+export const ExhibitionDate = styled.p`
+  font-size: 0.9rem;
+  margin: 4px 0 8px;
+  color: ${luminexTheme.colors.text};
+`;
+
+export const ExhibitionDescription = styled.p`
+  margin-top: 8px;
+  text-align: left;
+`;
+
+export const ExhibitionAddress = styled.p`
+  margin-top: 8px;
+  font-weight: bold;
+`;


### PR DESCRIPTION
## Summary
- implement `Exhibitions` component fetching exhibitions from Sanity
- style exhibitions grid and items
- show exhibitions section after Hero section

## Testing
- `npm test --silent -- -w 0`
- `npx tsc -p tsconfig.json --noEmit` *(fails: errors in @sanity/client types)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688a8b6d324c8329b3eea170c3b8d55d