### PR TITLE
Make filter section collapsible

### DIFF
--- a/src/components/Filter/Filter.tsx
+++ b/src/components/Filter/Filter.tsx
@@ -1,6 +1,11 @@
 import React, { useEffect, useState } from 'react';
 import { sanityClient } from '../../sanityClient';
-import { FilterWrapper, CheckboxLabel } from './styled';
+import {
+  FilterContainer,
+  FilterWrapper,
+  CheckboxLabel,
+  ToggleButton,
+} from './styled';
 
 interface FilterProps {
   selectedTags: string[];
@@ -9,6 +14,7 @@ interface FilterProps {
 
 export default function Filter({ selectedTags, onChange }: FilterProps) {
   const [tags, setTags] = useState<string[]>([]);
+  const [open, setOpen] = useState(false);
 
   useEffect(() => {
     async function fetchTags() {
@@ -38,19 +44,26 @@ export default function Filter({ selectedTags, onChange }: FilterProps) {
   };
 
   return (
-    <FilterWrapper>
-      {tags.map((tag) => (
-        <CheckboxLabel key={tag}>
-          <input
-            type="checkbox"
-            id={tag}
-            name={tag}
-            checked={selectedTags.includes(tag)}
-            onChange={() => handleCheckboxChange(tag)}
-          />
-          <span>{tag}</span>
-        </CheckboxLabel>
-      ))}
-    </FilterWrapper>
+    <FilterContainer>
+      <ToggleButton onClick={() => setOpen((o) => !o)} aria-expanded={open}>
+        Filtr {open ? '▲' : '▼'}
+      </ToggleButton>
+      {open && (
+        <FilterWrapper>
+          {tags.map((tag) => (
+            <CheckboxLabel key={tag}>
+              <input
+                type="checkbox"
+                id={tag}
+                name={tag}
+                checked={selectedTags.includes(tag)}
+                onChange={() => handleCheckboxChange(tag)}
+              />
+              <span>{tag}</span>
+            </CheckboxLabel>
+          ))}
+        </FilterWrapper>
+      )}
+    </FilterContainer>
   );
 }

--- a/src/components/Filter/styled.ts
+++ b/src/components/Filter/styled.ts
@@ -20,6 +20,23 @@ export const FilterWrapper = styled.section`
   }
 `;
 
+export const FilterContainer = styled.div`
+  width: 100%;
+`;
+
+export const ToggleButton = styled.button`
+  width: 100%;
+  padding: 12px;
+  background-color: ${luminexTheme.colors.primary};
+  color: ${luminexTheme.colors.white};
+  border: none;
+  border-radius: 4px;
+  font-size: 1rem;
+  font-weight: bold;
+  cursor: pointer;
+  margin-bottom: 12px;
+`;
+
 export const CheckboxLabel = styled.label`
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- revert dropdown filter change
- keep checkbox grid and add a toggle button to collapse/expand the filter section

## Testing
- `npm test --silent`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688afd3f503c83298e678fda04c1c78f