### PR TITLE
Replace arrow icons with chevrons

### DIFF
--- a/src/components/ArrowUpIcon/index.tsx
+++ b/src/components/ArrowUpIcon/index.tsx
@@ -6,6 +6,13 @@ export type ArrowUpIconProps = {
 
 export const ArrowUpIcon: React.FC<ArrowUpIconProps> = ({ color = 'currentColor' }) => (
   <svg width="48" height="48" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-    <path d="M12 4l-8 8h5v8h6v-8h5l-8-8z" fill={color} />
+    <polyline
+      points="6 14 12 8 18 14"
+      fill="none"
+      stroke={color}
+      strokeWidth="4"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
   </svg>
 );


### PR DESCRIPTION
## Summary
- update `ArrowUpIcon` to use a chevron graphic

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688ba1cd06e08329b454115a2923c2d5