### PR TITLE
Fix modal scroll blocking and arrow visibility

### DIFF
--- a/src/components/Gallery/Gallery.tsx
+++ b/src/components/Gallery/Gallery.tsx
@@ -21,6 +21,14 @@ export default function Gallery({ selectedTags }: GalleryProps) {
   const tapTimeout = useRef<NodeJS.Timeout | null>(null);
 
   useEffect(() => {
+    if (modalOpen) {
+      document.body.classList.add('modal-open');
+    } else {
+      document.body.classList.remove('modal-open');
+    }
+  }, [modalOpen]);
+
+  useEffect(() => {
     async function fetchImages() {
       const query = `*[_type == "imageAsset"]|order(_createdAt desc){
         _id,

--- a/src/components/ScrollToTopButton/index.tsx
+++ b/src/components/ScrollToTopButton/index.tsx
@@ -7,10 +7,20 @@ export default function ScrollToTopButton() {
 
   useEffect(() => {
     const handleScroll = () => {
-      setVisible(window.scrollY > 100);
+      const noModal = !document.body.classList.contains('modal-open');
+      setVisible(window.scrollY > 100 && noModal);
     };
+
+    const observer = new MutationObserver(handleScroll);
+    observer.observe(document.body, { attributes: true, attributeFilter: ['class'] });
+
     window.addEventListener('scroll', handleScroll);
-    return () => window.removeEventListener('scroll', handleScroll);
+    // set initial state
+    handleScroll();
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+      observer.disconnect();
+    };
   }, []);
 
   const scrollToTop = () => {
@@ -18,7 +28,12 @@ export default function ScrollToTopButton() {
   };
 
   return (
-    <Button onClick={scrollToTop} $visible={visible} aria-label="scroll to top">
+    <Button
+      onClick={scrollToTop}
+      $visible={visible}
+      aria-label="scroll to top"
+      className="scroll-to-top"
+    >
       <ArrowUpIcon color="white" />
     </Button>
   );

--- a/src/styled.ts
+++ b/src/styled.ts
@@ -4,6 +4,15 @@ export const GlobalStyle = createGlobalStyle`
   html {
     scroll-behavior: smooth;
   }
+
+  body.modal-open {
+    overflow: hidden;
+    touch-action: none;
+  }
+
+  body.modal-open .scroll-to-top {
+    display: none !important;
+  }
 `;
 
 export const Layout = styled.div``;


### PR DESCRIPTION
## Summary
- prevent page scrolling while ModalCarousel is open
- auto-hide ScrollToTopButton when a modal is active

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688ca09453188329ac1cbcf8ec7c8c7a