### PR TITLE
Fix scroll lock when modal open

### DIFF
--- a/src/components/Gallery/Gallery.tsx
+++ b/src/components/Gallery/Gallery.tsx
@@ -21,10 +21,13 @@ export default function Gallery({ selectedTags }: GalleryProps) {
   const tapTimeout = useRef<NodeJS.Timeout | null>(null);
 
   useEffect(() => {
+    const html = document.documentElement;
     if (modalOpen) {
       document.body.classList.add('modal-open');
+      html.classList.add('modal-open');
     } else {
       document.body.classList.remove('modal-open');
+      html.classList.remove('modal-open');
     }
   }, [modalOpen]);
 

--- a/src/styled.ts
+++ b/src/styled.ts
@@ -5,6 +5,8 @@ export const GlobalStyle = createGlobalStyle`
     scroll-behavior: smooth;
   }
 
+
+  html.modal-open,
   body.modal-open {
     overflow: hidden;
     touch-action: none;


### PR DESCRIPTION
## Summary
- prevent page scroll by also adding `modal-open` class to `<html>` when the gallery modal is displayed
- update global styles to hide overflow on both `html` and `body`

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_688ce91b05888329a535e118081fefcd