### PR TITLE
Add message when gallery filter returns no results

### DIFF
--- a/src/components/Gallery/Gallery.tsx
+++ b/src/components/Gallery/Gallery.tsx
@@ -5,6 +5,7 @@ import {
   TagsWrapper,
   PortfolioHeading,
   LikeButton,
+  NoResultsMessage,
 } from './styled';
 import ImageSkeleton from './ImageSkeleton';
 import ModalCarousel from '../ModalCarousel/ModalCarousel'; // ModalCarousel nyní očekává images: {url, description}[]
@@ -125,6 +126,9 @@ export default function Gallery({ selectedTags }: GalleryProps) {
   return (
     <>
       <GalleryWrapper>
+        {filteredImages.length === 0 && (
+          <NoResultsMessage>Nic nenalezeno.</NoResultsMessage>
+        )}
         {filteredImages.map((img, index) => (
           <GalleryItem key={img._id}>
             <h2>{img.title || `Foto ${index + 1}`}</h2>

--- a/src/components/Gallery/styled.ts
+++ b/src/components/Gallery/styled.ts
@@ -57,3 +57,12 @@ export const LikeButton = styled.button`
   cursor: pointer;
   padding: 8px 0;
 `;
+
+export const NoResultsMessage = styled.p`
+  grid-column: 1 / -1;
+  text-align: center;
+  font-size: 1.4rem;
+  font-weight: 600;
+  color: ${luminexTheme.colors.primary};
+  margin: 40px 0;
+`;


### PR DESCRIPTION
## Summary
- add `NoResultsMessage` styled component
- show a 'Nic nenalezeno.' note when the gallery filter matches no images

## Testing
- `CI=true npm test --silent -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_688cf5c9249c83299dbc2884440a8fb6