### PR TITLE
Add bottom border to Portfolio

### DIFF
--- a/src/components/Portfolio/styled.ts
+++ b/src/components/Portfolio/styled.ts
@@ -6,6 +6,7 @@ export const PortfolioWrapper = styled.div`
   max-width: ${luminexTheme.breakpoints.desktop};
   margin: 0 auto;
   margin: 40px auto 0 auto;
+  border-bottom: 1px solid ${luminexTheme.colors.primary};
 `;
 
 export const PortfolioTitle = styled.h2`


### PR DESCRIPTION
## Summary
- add a bottom border to Portfolio section for visual separation

## Testing
- `npm test --silent -- -u`

------
https://chatgpt.com/codex/tasks/task_e_688cf84907108329abfc96732171024e